### PR TITLE
Remove .terraform.lock.hcl from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,3 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
-.terraform.lock.hcl


### PR DESCRIPTION
`.terraform.lock.hcl` had to be removed from .gitignore, because TF can guarantee the same provider selection in future If I would like to make `terraform init` again.